### PR TITLE
[ROB-1101] updated demo-alert to use alertmanager api-v2

### DIFF
--- a/robusta_cli/demo_alert.py
+++ b/robusta_cli/demo_alert.py
@@ -121,7 +121,7 @@ def create_demo_alert(
         "curl",
         "-X",
         "POST",
-        f"{alertmanager_url}/api/v1/alerts",
+        f"{alertmanager_url}/api/v2/alerts",
         "-H",
         "Content-Type: application/json",
         "-d",


### PR DESCRIPTION
tested demo-alert
<img width="835" alt="Screen Shot 2025-05-12 at 10 14 05" src="https://github.com/user-attachments/assets/45f3adee-1492-4cae-a4e8-3d43227cd14d" />

before this pr would have issues in newer alert managers

```
time=2025-05-12T07:15:31.655Z level=WARN source=v1_deprecation_router.go:49 msg="v1 API received a request on a removed endpoint" component=api version=v1 path=/api/v1/alerts method=POST
```