### PR TITLE
Bump urllib3 minimum version to >2.6.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -974,14 +974,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
+    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
 
 [package.extras]
@@ -1010,4 +1010,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9, <3.13"
-content-hash = "51143e6528a3145577eaa69d4e5529788b1d21c43a452c7ada8950c90a536735"
+content-hash = "fbe1712702d075c0437ba8333eec2846030351c775bde2eb735c5ec0ca7a6f8d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1010,4 +1010,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9, <3.13"
-content-hash = "fbe1712702d075c0437ba8333eec2846030351c775bde2eb735c5ec0ca7a6f8d"
+content-hash = "920eefc8b90638f1bbf55066e748900cefd117942b869c0ef8fd30f893578d2c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ types-toml = "^0.10.2"
 toml = "^0.10.2"
 hikaru-model-28 = "^1.1.0"
 kubernetes = "^29"
-urllib3 = ">2.6.2"
+urllib3 = ">=2.6.3"
 click = "8.1.8"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ types-toml = "^0.10.2"
 toml = "^0.10.2"
 hikaru-model-28 = "^1.1.0"
 kubernetes = "^29"
-urllib3 = ">2.6.0"
+urllib3 = ">2.6.2"
 click = "8.1.8"
 
 


### PR DESCRIPTION
## Summary
Updated the urllib3 dependency constraint to require version greater than 2.6.2, up from the previous >2.6.0 requirement.

## Changes
- Updated `urllib3` version constraint in `pyproject.toml` from `">2.6.0"` to `">2.6.2"`

## Details
This change ensures the project uses a more recent minimum version of urllib3, likely to include bug fixes or security improvements available in versions 2.6.1 and 2.6.2.

https://claude.ai/code/session_01Skb1JqMdUYMUdCyv1QAAe4