### PR TITLE
  ROB-3778 Add ROBUSTA_API_ENDPOINT environment variable to config generation

### DIFF
--- a/robusta_cli/main.py
+++ b/robusta_cli/main.py
@@ -274,6 +274,10 @@ def gen_config(
                 "name": "ROBUSTA_TELEMETRY_ENDPOINT",
                 "value": backend_profile.robusta_telemetry_endpoint,
             },
+            {
+                "name": "ROBUSTA_API_ENDPOINT",
+                "value": backend_profile.robusta_cloud_api_host,
+            },
         ]
 
     if is_small_cluster:


### PR DESCRIPTION
## Summary
Added support for configuring the Robusta API endpoint through an environment variable during config generation.

## Key Changes
- Added `ROBUSTA_API_ENDPOINT` environment variable configuration to the `gen_config` function
- The variable is populated with the value from `backend_profile.robusta_cloud_api_host`
- This allows the Robusta API host to be dynamically configured alongside other telemetry and backend settings

## Implementation Details
The new environment variable is added to the configuration list alongside the existing `ROBUSTA_TELEMETRY_ENDPOINT` variable, maintaining consistency with the current configuration pattern. This enables users to specify a custom Robusta Cloud API host during the initial setup process.

https://claude.ai/code/session_01Gmktv6iyg4B1Pfcpv979ao